### PR TITLE
Fix for dark theme on file list

### DIFF
--- a/source/usr/local/emhttp/plugins/lxc/LXCSettings.page
+++ b/source/usr/local/emhttp/plugins/lxc/LXCSettings.page
@@ -9,6 +9,7 @@ $default_path = shell_exec("/usr/local/emhttp/plugins/lxc/include/exec.sh defaul
 $avail_bridges = shell_exec("/usr/local/emhttp/plugins/lxc/include/exec.sh avail_bridges");
 $selected_bridge = shell_exec("/usr/local/emhttp/plugins/lxc/include/exec.sh selected_bridge");
 $selected_timeout = shell_exec("/usr/local/emhttp/plugins/lxc/include/exec.sh selected_timeout");
+$bgcolor           = strstr('white,azure',$display['theme']) ? '#f2f2f2' : '#1c1c1c';
 ?>
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/jquery.filetree.css')?>">
 <style>


### PR DESCRIPTION
Fix for filetree back ground if using dark theme, was white and text was unreadable.

![image](https://user-images.githubusercontent.com/39065407/180608603-da3da456-fd9e-46eb-934a-eec1a413814b.png)
